### PR TITLE
Optimize Live Event tool data response size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fpl-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Model Context Protocol (MCP) server for the Fantasy Premier League API",
   "type": "module",
   "main": "build/src/server.js",

--- a/src/fpl.ts
+++ b/src/fpl.ts
@@ -3,26 +3,52 @@ export async function getFixturesForGameweek(gw: number): Promise<any> {
   return res.json();
 }
 
-export async function getLiveEvent(gw: number): Promise<any> {
+async function fetchLiveEventRaw(gw: number): Promise<any> {
   const res = await fetch(`https://fantasy.premierleague.com/api/event/${gw}/live/`);
   return res.json();
 }
 
-export async function getLiveElementStats(gw: number, elementIds?: number[]): Promise<any> {
-  const data = await getLiveEvent(gw);
+export async function getLiveEvent(gw: number, elementIds?: number[]): Promise<any> {
+  const data = await fetchLiveEventRaw(gw);
 
-  if (!elementIds || elementIds.length === 0) {
-    // If no specific elements requested, return all
-    return data;
+  // Filter elements if specific IDs requested
+  let elements = data.elements || [];
+  if (elementIds && elementIds.length > 0) {
+    elements = elements.filter((element: any) => elementIds.includes(element.id));
   }
 
-  // Filter to only return data for requested element IDs
-  const filteredElements = data.elements.filter((element: any) =>
-    elementIds.includes(element.id)
-  );
+  // Return only essential stats for each player
+  const focusedElements = elements.map((element: any) => ({
+    id: element.id,
+    stats: {
+      minutes: element.stats.minutes,
+      goals_scored: element.stats.goals_scored,
+      assists: element.stats.assists,
+      clean_sheets: element.stats.clean_sheets,
+      goals_conceded: element.stats.goals_conceded,
+      own_goals: element.stats.own_goals,
+      penalties_saved: element.stats.penalties_saved,
+      penalties_missed: element.stats.penalties_missed,
+      yellow_cards: element.stats.yellow_cards,
+      red_cards: element.stats.red_cards,
+      saves: element.stats.saves,
+      bonus: element.stats.bonus,
+      bps: element.stats.bps,
+      influence: element.stats.influence,
+      creativity: element.stats.creativity,
+      threat: element.stats.threat,
+      ict_index: element.stats.ict_index,
+      starts: element.stats.starts,
+      expected_goals: element.stats.expected_goals,
+      expected_assists: element.stats.expected_assists,
+      expected_goal_involvements: element.stats.expected_goal_involvements,
+      expected_goals_conceded: element.stats.expected_goals_conceded,
+      total_points: element.stats.total_points,
+    }
+  }));
 
   return {
-    elements: filteredElements
+    elements: focusedElements
   };
 }
 

--- a/src/fpl.ts
+++ b/src/fpl.ts
@@ -8,6 +8,24 @@ export async function getLiveEvent(gw: number): Promise<any> {
   return res.json();
 }
 
+export async function getLiveElementStats(gw: number, elementIds?: number[]): Promise<any> {
+  const data = await getLiveEvent(gw);
+
+  if (!elementIds || elementIds.length === 0) {
+    // If no specific elements requested, return all
+    return data;
+  }
+
+  // Filter to only return data for requested element IDs
+  const filteredElements = data.elements.filter((element: any) =>
+    elementIds.includes(element.id)
+  );
+
+  return {
+    elements: filteredElements
+  };
+}
+
 export async function getEntryHistory(entryId: number): Promise<any> {
   const res = await fetch(`https://fantasy.premierleague.com/api/entry/${entryId}/history/`);
   return res.json();

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import {
   getEntry,
   getFixturesForGameweek,
   getLiveEvent,
+  getLiveElementStats,
   getEntryHistory,
   getEntryTransfers,
   getEntryPicks,
@@ -49,10 +50,27 @@ server.registerTool("getFixturesForGameweek", {
 // Tool for live results of a gameweek
 server.registerTool("getLiveEvent", {
   title: "Get Live Event",
-  description: "Fetch live results for a given gameweek",
+  description: "Fetch live results for a given gameweek (returns all 600+ players, very large)",
   inputSchema: { gw: z.number() }
 }, async ({ gw }) => {
   const data = await getLiveEvent(gw);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(data)
+      }
+    ]
+  };
+});
+
+// Tool for live element stats (focused version)
+server.registerTool("getLiveElementStats", {
+  title: "Get Live Element Stats",
+  description: "Fetch live stats for specific players in a gameweek. Provide elementIds array to filter specific players, or omit to get all players.",
+  inputSchema: { gw: z.number(), elementIds: z.array(z.number()).optional() }
+}, async ({ gw, elementIds }) => {
+  const data = await getLiveElementStats(gw, elementIds);
   return {
     content: [
       {

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,6 @@ import {
   getEntry,
   getFixturesForGameweek,
   getLiveEvent,
-  getLiveElementStats,
   getEntryHistory,
   getEntryTransfers,
   getEntryPicks,
@@ -50,27 +49,10 @@ server.registerTool("getFixturesForGameweek", {
 // Tool for live results of a gameweek
 server.registerTool("getLiveEvent", {
   title: "Get Live Event",
-  description: "Fetch live results for a given gameweek (returns all 600+ players, very large)",
-  inputSchema: { gw: z.number() }
-}, async ({ gw }) => {
-  const data = await getLiveEvent(gw);
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify(data)
-      }
-    ]
-  };
-});
-
-// Tool for live element stats (focused version)
-server.registerTool("getLiveElementStats", {
-  title: "Get Live Element Stats",
-  description: "Fetch live stats for specific players in a gameweek. Provide elementIds array to filter specific players, or omit to get all players.",
+  description: "Fetch focused live stats for a gameweek. Optionally filter to specific players by providing elementIds array.",
   inputSchema: { gw: z.number(), elementIds: z.array(z.number()).optional() }
 }, async ({ gw, elementIds }) => {
-  const data = await getLiveElementStats(gw, elementIds);
+  const data = await getLiveEvent(gw, elementIds);
   return {
     content: [
       {


### PR DESCRIPTION
…1.0.2

- Add getLiveElementStats function to filter live data by specific player IDs
- Add new getLiveElementStats tool to MCP server
- Update getLiveEvent description to warn about large data size
- Increment package version from 1.0.1 to 1.0.2

This follows the same optimization pattern used for bootstrap-static data, allowing users to request only the player stats they need instead of receiving data for all 600+ players.