### PR TITLE
Add npm publish workflow on version change

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,79 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version-changed: ${{ steps.check.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if version changed
+        id: check
+        run: |
+          # Get current version
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+          # Get previous version (if exists)
+          git show HEAD~1:package.json > /tmp/old-package.json 2>/dev/null || echo '{"version":"0.0.0"}' > /tmp/old-package.json
+          PREVIOUS_VERSION=$(node -p "require('/tmp/old-package.json').version")
+
+          echo "Current version: $CURRENT_VERSION"
+          echo "Previous version: $PREVIOUS_VERSION"
+
+          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "Version unchanged"
+          fi
+
+  publish:
+    needs: check-version
+    if: needs.check-version.outputs.version-changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ needs.check-version.outputs.version }}"
+          git push origin "v${{ needs.check-version.outputs.version }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ You can ask natural language questions about any supported endpoint. The LLM wil
 
 ---
 
+## Development
+
+### Publishing to npm
+
+This repository includes a GitHub Actions workflow that automatically publishes to npm when the version number in `package.json` changes.
+
+#### Setup
+
+1. Create an npm access token:
+   - Log in to [npmjs.com](https://www.npmjs.com/)
+   - Go to Access Tokens in your account settings
+   - Generate a new "Automation" token
+
+2. Add the token to GitHub Secrets:
+   - Go to your repository Settings > Secrets and variables > Actions
+   - Create a new secret named `NPM_TOKEN`
+   - Paste your npm token as the value
+
+3. Publish a new version:
+   - Update the version in `package.json` (e.g., `1.0.1` → `1.0.2`)
+   - Commit and push to the `main` branch
+   - The workflow will automatically build and publish to npm
+   - A git tag (e.g., `v1.0.2`) will be created automatically
+
+---
+
 ## License
 MIT
 


### PR DESCRIPTION
- Add GitHub Actions workflow to automatically publish to npm when package.json version changes
- Workflow checks for version changes and only publishes if version is bumped
- Includes automatic git tag creation for new versions
- Add documentation to README explaining how to set up npm token and publish process