### PR TITLE
fix: grant write permissions for git tag creation

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,7 +46,7 @@ jobs:
     if: needs.check-version.outputs.version-changed == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout code


### PR DESCRIPTION
Change contents permission from read to write to allow the workflow to push git tags after publishing to npm